### PR TITLE
227 fix timestamp pyfluxpro input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Data validation for formatting L2 control file for pyfluxpro. [#188](https://github.com/ncsa/ameriflux-pipeline/issues/188)
 - Data validation for formatting pyfluxpro output for Ameriflux submission. [#203](https://github.com/ncsa/ameriflux-pipeline/issues/203)
 - Created logging for met_data_merge. [#15](https://github.com/ncsa/ameriflux-pipeline/issues/15)
+- Added logging for pre_pyfluxpro. [#207](https://github.com/ncsa/ameriflux-pipeline/issues/207)
 
 ### Fixed
 - Python packaging of the codes so it can run in command prompt. [#70](https://github.com/ncsa/ameriflux-pipeline/issues/70)
@@ -73,6 +74,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed timestamp misalignment in csv file for ameriflux submission. [#198](https://github.com/ncsa/ameriflux-pipeline/issues/198)
 - Fixed timestamp shifts in met data merger module. [#220](https://github.com/ncsa/ameriflux-pipeline/issues/220)
 - Fixed timestamp duplication in met data merger module. [#224](https://github.com/ncsa/ameriflux-pipeline/issues/224)
+- Fixed starting timestamp in met data merger module. [#226](https://github.com/ncsa/ameriflux-pipeline/issues/226)
 - Fixed full output timestamp in pyfluxpro input excel sheet. [#227](https://github.com/ncsa/ameriflux-pipeline/issues/227)
 
 ### Changed

--- a/NOTES.md
+++ b/NOTES.md
@@ -64,8 +64,10 @@
 ### 18
 - netCDF4 python library is supported only in Python version 3.8. This pipeline has a strict requirement of Python 3.8
 ### 19
-- During merge of dat files / raw met files from the server, the end date is taken as the next day midnight and start date is taken as 30min before.
-- This is due to the timestamp shift of 30min in the mastermet processing which makes the Flux data file contain data for the whole year
+- During merge of dat files / raw met files from the server, the end date is taken as the next day midnight and start date is taken as 30min forward.
+- The start time will be 00:30 and the end time will be 00:00 of the next day. 
+- Campbell data logger timestamps refer to the end of a 30-minute period.
+- The timestamps are shifted behind my 30min in the mastermet processing, to reflect the starting time of the 30min period. This way the master met output will have timestamps from 00:00 to 23:30.
 ### 20
 - In 2021 there has been a program change resulting in the change of some datalogger met variables names. Hence when merging the met data, certain old variables names are to be changed to newer standardized variable names.
 - {'CM3Up_Avg': 'SWDn_Avg', 'CM3Dn_Avg': 'SWUp_Avg', 'CG3UpCo_Avg': 'LWDnCo_Avg', 'CG3DnCo_Avg': 'LWUpCo_Avg', 'NetTot_Avg': 'Rn_Avg', 'cnr1_T_C_Avg': 'CNR1TC_Avg', 'cnr1_T_K_Avg': 'CNR1TK_Avg', 'Rs_net_Avg': 'NetRs_Avg', 'Rl_net_Avg': 'NetRl_Avg' , 'VWC_': 'VWC1_', 'TC_':'TC1_'}

--- a/ameriflux_pipeline/met_data_merge.py
+++ b/ameriflux_pipeline/met_data_merge.py
@@ -85,7 +85,7 @@ def read_met_data(data_path):
                 df = pd.read_csv(data_path, sep=';', header=None, names=None, skiprows=1, quotechar='"',
                                  low_memory=False)
             except ParserError as e:
-                log.error("Exception in reading %s", data_path)
+                log.error("Exception in reading %s %s", data_path, e)
                 return None, None, None, None
 
     # process df to get meta data - column names and units
@@ -192,7 +192,7 @@ def data_processing(files, start_date, end_date):
     start_date = pd.to_datetime(start_date)  # 00:00 of start date
     end_date = pd.to_datetime(end_date)  # 00:00 of end date. get records till 00:00 of the next day
     # NOTES 19
-    start_date -= timedelta(minutes=30)  # shift 30min behind
+    start_date += timedelta(minutes=30)  # shift 30min forward
     end_date += timedelta(days=1)  # shift a day ahead which gives till 00:00 of next day
     met_data = met_data[(met_data['TIMESTAMP_datetime'] >= start_date) & (met_data['TIMESTAMP_datetime'] <= end_date)]
     # drop duplicate timestamps


### PR DESCRIPTION
## Description
This PR fixes the TIMESTAMP column of the full_output sheet in the generated pyfluxpro input excel sheet. The TIMESTAMP column in the full_output sheet now matches the timestamp in the ghg file (which if given in the 'filename' column). This 'TIMESTAMP' column value is 30min behind the 'time' column in the full_output sheet.

**Fixes #227**

[comment]: # (This project only accepts pull requests related to open issues.)
[comment]: # (If suggesting a new feature or change, please discuss it in an issue first.)
[comment]: # (If fixing a bug, there should be an issue describing it with steps to reproduce.)

## Review Time Estimate
_Please give your idea of how soon this pull request needs to be reviewed by selecting one of the options below. This can be based on the criticality of the issue at hand and/or other relevant factors._

[comment]: # (To select an option, please put an 'x' in the applicable box.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [ ] Immediately
- [x] Within a week
- [ ] When possible

## Type of changes
_Please select a relevant option:_

[comment]: # (To select an option, please put an 'x' in the applicable box.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Other (any another change that does not fall in one of the above categories.)

## Checklist:
_Please select all applicable options:_

[comment]: # (To select your options, please put an 'x' in the all boxes that apply.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [x] I have updated the [CHANGELOG](../CHANGELOG.md).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] My change requires updating the documentation.
- [ ] I have made necessary changes to the documentation.
- [ ] I have added tests related to my changes.
- [ ] My changes generate no new warnings.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

---

[comment]: # (Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates.)

